### PR TITLE
dynamic row count #1

### DIFF
--- a/lib/calendar_sheet.dart
+++ b/lib/calendar_sheet.dart
@@ -58,7 +58,7 @@ class CalendarSheetBody extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: List<Widget>.generate(
-          5,
+          ((_lastDayOfMonth + _weekDayOfFirstDayOfMonth - 1) / 7).ceil(),
           (row) => Expanded(
             child: Row(
               crossAxisAlignment: CrossAxisAlignment.stretch,


### PR DESCRIPTION
Fixes #1.
Output only as many week-rows as needed in month-sheet-view.